### PR TITLE
fix/refactor: strdup NULLチェック + ARRAY_GROWマクロ集約

### DIFF
--- a/src/array_grow.h
+++ b/src/array_grow.h
@@ -1,0 +1,21 @@
+#ifndef HAJIMU_ARRAY_GROW_H
+#define HAJIMU_ARRAY_GROW_H
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define ARRAY_GROW(ptr, count, cap, type, on_oom) \
+    do { \
+        if ((count) >= (cap)) { \
+            size_t _array_grow_new_cap = (cap) ? (size_t)(cap) * 2u : 8u; \
+            void *_array_grow_tmp = realloc((ptr), _array_grow_new_cap * sizeof(type)); \
+            if (_array_grow_tmp == NULL) { \
+                fprintf(stderr, "Out of memory in %s:%d\n", __FILE__, __LINE__); \
+                on_oom; \
+            } \
+            (ptr) = _array_grow_tmp; \
+            (cap) = _array_grow_new_cap; \
+        } \
+    } while (0)
+
+#endif

--- a/src/evaluator.c
+++ b/src/evaluator.c
@@ -3,6 +3,7 @@
  */
 
 #include "evaluator.h"
+#include "array_grow.h"
 #include "parser.h"
 #include "http.h"
 #include "async.h"
@@ -1552,19 +1553,13 @@ static Value evaluate_call(Evaluator *eval, ASTNode *node) {
                 // 配列の各要素を引数に追加
                 for (int j = 0; j < spread_val.array.length; j++) {
                     if (actual_arg_count >= args_capacity) {
-                        args_capacity *= 2;
-                        Value *tmp = realloc(args, sizeof(Value) * args_capacity);
-                        if (!tmp) { free(args); return value_null(); }
-                        args = tmp;
+                        ARRAY_GROW(args, actual_arg_count, args_capacity, Value, free(args); return value_null());
                     }
                     args[actual_arg_count++] = value_copy(spread_val.array.elements[j]);
                 }
             } else {
                 if (actual_arg_count >= args_capacity) {
-                    args_capacity *= 2;
-                    Value *tmp = realloc(args, sizeof(Value) * args_capacity);
-                    if (!tmp) { free(args); return value_null(); }
-                    args = tmp;
+                    ARRAY_GROW(args, actual_arg_count, args_capacity, Value, free(args); return value_null());
                 }
                 args[actual_arg_count] = evaluate(eval, arg_node);
                 if (eval->had_error) {
@@ -2823,10 +2818,7 @@ static Value evaluate_string_interpolation(Evaluator *eval, const char *str, int
         if (*p == '\\' && *(p + 1) == '{') {
             // エスケープされた{はそのまま
             if (length + 1 >= capacity) {
-                capacity *= 2;
-                char *tmp = realloc(result, capacity);
-                if (!tmp) { free(result); return value_string(""); }
-                result = tmp;
+                ARRAY_GROW(result, length + 1, capacity, char, free(result); return value_string(""));
             }
             result[length++] = '{';
             p += 2;
@@ -2879,10 +2871,7 @@ static Value evaluate_string_interpolation(Evaluator *eval, const char *str, int
                     char *val_str = value_to_string(val);
                     int val_len = strlen(val_str);
                     while (length + val_len + 1 >= capacity) {
-                        capacity *= 2;
-                        char *tmp = realloc(result, capacity);
-                        if (!tmp) { free(result); free(val_str); return value_string(""); }
-                        result = tmp;
+                        ARRAY_GROW(result, length + val_len + 1, capacity, char, free(result); free(val_str); return value_string(""));
                     }
                     memcpy(result + length, val_str, val_len);
                     length += val_len;
@@ -2892,10 +2881,7 @@ static Value evaluate_string_interpolation(Evaluator *eval, const char *str, int
                 // 補間式として無効 → { と内容をリテラルとしてコピー
                 int total = 1 + expr_len + 1; // { + 内容 + }
                 while (length + total + 1 >= capacity) {
-                    capacity *= 2;
-                    char *tmp = realloc(result, capacity);
-                    if (!tmp) { free(result); return value_string(""); }
-                    result = tmp;
+                    ARRAY_GROW(result, length + total + 1, capacity, char, free(result); return value_string(""));
                 }
                 result[length++] = '{';
                 memcpy(result + length, expr_str, expr_len);
@@ -2911,10 +2897,7 @@ static Value evaluate_string_interpolation(Evaluator *eval, const char *str, int
             int char_len = utf8_char_length((unsigned char)*p);
             if (char_len == 0) char_len = 1;
             while (length + char_len + 1 >= capacity) {
-                capacity *= 2;
-                char *tmp = realloc(result, capacity);
-                if (!tmp) { free(result); return value_string(""); }
-                result = tmp;
+                ARRAY_GROW(result, length + char_len + 1, capacity, char, free(result); return value_string(""));
             }
             memcpy(result + length, p, char_len);
             length += char_len;
@@ -4684,10 +4667,7 @@ static Value builtin_regex_replace(int argc, Value *argv) {
         // マッチ前の部分をコピー
         int prefix_len = match.rm_so;
         while (buf_len + prefix_len + rep_len + 1 >= buf_capacity) {
-            buf_capacity *= 2;
-            char *tmp = realloc(buf, buf_capacity);
-            if (!tmp) { free(buf); regfree(&regex); return value_string(""); }
-            buf = tmp;
+            ARRAY_GROW(buf, buf_len + prefix_len + rep_len + 1, buf_capacity, char, free(buf); regfree(&regex); return value_string(""));
         }
         memcpy(buf + buf_len, src, prefix_len);
         buf_len += prefix_len;
@@ -4710,10 +4690,7 @@ static Value builtin_regex_replace(int argc, Value *argv) {
     // 残りの部分をコピー
     int remaining = strlen(src);
     while (buf_len + remaining + 1 >= buf_capacity) {
-        buf_capacity *= 2;
-        char *tmp = realloc(buf, buf_capacity);
-        if (!tmp) { free(buf); regfree(&regex); return value_string(""); }
-        buf = tmp;
+        ARRAY_GROW(buf, buf_len + remaining + 1, buf_capacity, char, free(buf); regfree(&regex); return value_string(""));
     }
     memcpy(buf + buf_len, src, remaining);
     buf_len += remaining;
@@ -4759,10 +4736,7 @@ static Value builtin_exec(int argc, Value *argv) {
     while (fgets(chunk, sizeof(chunk), pipe) != NULL) {
         int chunk_len = strlen(chunk);
         while (length + chunk_len + 1 >= capacity) {
-            capacity *= 2;
-            char *tmp = realloc(buffer, capacity);
-            if (!tmp) { free(buffer); pclose(pipe); return value_string(""); }
-            buffer = tmp;
+            ARRAY_GROW(buffer, length + chunk_len + 1, capacity, char, free(buffer); pclose(pipe); return value_string(""));
         }
         memcpy(buffer + length, chunk, chunk_len);
         length += chunk_len;

--- a/src/http.c
+++ b/src/http.c
@@ -5,6 +5,7 @@
  */
 
 #include "http.h"
+#include "array_grow.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -110,14 +111,14 @@ static Value json_parse_string(JsonParser *p) {
                     
                     // UTF-8にエンコード
                     if (codepoint < 0x80) {
-                        if (length + 1 >= capacity) { capacity *= 2; char *tmp = realloc(buffer, capacity); if (!tmp) { free(buffer); return value_null(); } buffer = tmp; }
+                        ARRAY_GROW(buffer, length + 1, capacity, char, free(buffer); return value_null());
                         buffer[length++] = (char)codepoint;
                     } else if (codepoint < 0x800) {
-                        if (length + 2 >= capacity) { capacity *= 2; char *tmp = realloc(buffer, capacity); if (!tmp) { free(buffer); return value_null(); } buffer = tmp; }
+                        ARRAY_GROW(buffer, length + 2, capacity, char, free(buffer); return value_null());
                         buffer[length++] = (char)(0xC0 | (codepoint >> 6));
                         buffer[length++] = (char)(0x80 | (codepoint & 0x3F));
                     } else {
-                        if (length + 3 >= capacity) { capacity *= 2; char *tmp = realloc(buffer, capacity); if (!tmp) { free(buffer); return value_null(); } buffer = tmp; }
+                        ARRAY_GROW(buffer, length + 3, capacity, char, free(buffer); return value_null());
                         buffer[length++] = (char)(0xE0 | (codepoint >> 12));
                         buffer[length++] = (char)(0x80 | ((codepoint >> 6) & 0x3F));
                         buffer[length++] = (char)(0x80 | (codepoint & 0x3F));
@@ -129,8 +130,7 @@ static Value json_parse_string(JsonParser *p) {
         }
         
         if (length + 1 >= capacity) {
-            capacity *= 2;
-            buffer = realloc(buffer, capacity);
+            ARRAY_GROW(buffer, length + 1, capacity, char, free(buffer); return value_null());
         }
         buffer[length++] = c;
     }
@@ -298,10 +298,7 @@ static void sb_init(StringBuffer *sb) {
 
 static void sb_append(StringBuffer *sb, const char *str, int len) {
     while (sb->length + len + 1 >= sb->capacity) {
-        sb->capacity *= 2;
-        char *tmp = realloc(sb->data, sb->capacity);
-        if (!tmp) return;
-        sb->data = tmp;
+        ARRAY_GROW(sb->data, sb->length + len + 1, sb->capacity, char, return);
     }
     memcpy(sb->data + sb->length, str, len);
     sb->length += len;

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -5,6 +5,7 @@
  */
 
 #include "lexer.h"
+#include "array_grow.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -533,8 +534,7 @@ static Token scan_multiline_string(Lexer *lexer) {
                 case '0': c = '\0'; break;
                 default:
                     if (length + 1 >= capacity) {
-                        capacity *= 2;
-                        buffer = realloc(buffer, capacity);
+                        ARRAY_GROW(buffer, length + 1, capacity, char, abort());
                     }
                     buffer[length++] = '\\';
                     c = next;
@@ -542,8 +542,7 @@ static Token scan_multiline_string(Lexer *lexer) {
         }
         
         if (length + 1 >= capacity) {
-            capacity *= 2;
-            buffer = realloc(buffer, capacity);
+            ARRAY_GROW(buffer, length + 1, capacity, char, abort());
         }
         buffer[length++] = c;
     }
@@ -591,8 +590,7 @@ static Token scan_string(Lexer *lexer) {
                 default:
                     // 不明なエスケープはそのまま
                     if (length + 1 >= capacity) {
-                        capacity *= 2;
-                        buffer = realloc(buffer, capacity);
+                        ARRAY_GROW(buffer, length + 1, capacity, char, abort());
                     }
                     buffer[length++] = '\\';
                     c = next;
@@ -601,8 +599,7 @@ static Token scan_string(Lexer *lexer) {
         
         // バッファに追加
         if (length + 1 >= capacity) {
-            capacity *= 2;
-            buffer = realloc(buffer, capacity);
+            ARRAY_GROW(buffer, length + 1, capacity, char, abort());
         }
         buffer[length++] = c;
     }

--- a/src/main.c
+++ b/src/main.c
@@ -162,7 +162,11 @@ static void repl_history_add(const char *line) {
         memmove(repl_history, repl_history + 1, (REPL_HISTORY_MAX - 1) * sizeof(char *));
         repl_history_count--;
     }
-    repl_history[repl_history_count++] = strdup(line);
+    char *history_line = strdup(line);
+    if (history_line == NULL) {
+        return;
+    }
+    repl_history[repl_history_count++] = history_line;
 }
 
 static void repl_history_free(void) {

--- a/src/parser.c
+++ b/src/parser.c
@@ -5,6 +5,7 @@
  */
 
 #include "parser.h"
+#include "array_grow.h"
 #include "diag.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -278,10 +279,7 @@ static Parameter *parse_parameters(Parser *parser, int *count) {
     
     do {
         if (*count >= capacity) {
-            capacity *= 2;
-            Parameter *tmp = realloc(params, sizeof(Parameter) * capacity);
-            if (!tmp) { free(params); return NULL; }
-            params = tmp;
+            ARRAY_GROW(params, *count, capacity, Parameter, free(params); return NULL);
         }
         
         // 可変長引数（*引数名）
@@ -598,10 +596,7 @@ static ASTNode *var_declaration(Parser *parser, bool is_const) {
             do {
                 consume(parser, TOKEN_IDENTIFIER, "変数名が必要です");
                 if (name_count >= name_capacity) {
-                    name_capacity *= 2;
-                    char **tmp = realloc(names, sizeof(char*) * name_capacity);
-                    if (!tmp) { free(names); return NULL; }
-                    names = tmp;
+                    ARRAY_GROW(names, name_count, name_capacity, char *, free(names); return NULL);
                 }
                 names[name_count++] = copy_token_string(&parser->previous);
             } while (match(parser, TOKEN_COMMA));
@@ -948,10 +943,7 @@ static ASTNode *match_statement(Parser *parser) {
         case_values[value_count++] = expression(parser);
         while (match(parser, TOKEN_COMMA)) {
             if (value_count >= value_capacity) {
-                value_capacity *= 2;
-                ASTNode **tmp = realloc(case_values, sizeof(ASTNode *) * value_capacity);
-                if (!tmp) { free(case_values); return NULL; }
-                case_values = tmp;
+                ARRAY_GROW(case_values, value_count, value_capacity, ASTNode *, free(case_values); return NULL);
             }
             case_values[value_count++] = expression(parser);
         }
@@ -1076,16 +1068,8 @@ static ASTNode *enum_definition(Parser *parser) {
         if (check(parser, TOKEN_END)) break;
         
         if (count >= capacity) {
-            capacity *= 2;
-            char **tmp_k = realloc(keys, sizeof(char *) * capacity);
-            ASTNode **tmp_v = realloc(values, sizeof(ASTNode *) * capacity);
-            if (!tmp_k || !tmp_v) {
-                free(tmp_k ? tmp_k : keys);
-                free(tmp_v ? tmp_v : values);
-                return NULL;
-            }
-            keys = tmp_k;
-            values = tmp_v;
+            ARRAY_GROW(keys, count, capacity, char *, free(keys); free(values); return NULL);
+            ARRAY_GROW(values, count, capacity, ASTNode *, free(keys); free(values); return NULL);
         }
         
         // メンバー名
@@ -1632,8 +1616,7 @@ static ASTNode *finish_call(Parser *parser, ASTNode *callee) {
     if (!check(parser, TOKEN_RPAREN)) {
         do {
             if (arg_count >= capacity) {
-                capacity *= 2;
-                args = realloc(args, sizeof(ASTNode *) * capacity);
+                ARRAY_GROW(args, arg_count, capacity, ASTNode *, abort());
             }
             // スプレッド演算子 ...配列
             if (match(parser, TOKEN_SPREAD)) {
@@ -1770,8 +1753,7 @@ static ASTNode *primary(Parser *parser) {
             
             while (match(parser, TOKEN_COMMA)) {
                 if (count >= capacity) {
-                    capacity *= 2;
-                    elements = realloc(elements, sizeof(ASTNode *) * capacity);
+                    ARRAY_GROW(elements, count, capacity, ASTNode *, abort());
                 }
                 if (check(parser, TOKEN_RBRACKET)) {
                     break;
@@ -1802,9 +1784,8 @@ static ASTNode *primary(Parser *parser) {
         if (!check(parser, TOKEN_RBRACE)) {
             do {
                 if (count >= capacity) {
-                    capacity *= 2;
-                    keys = realloc(keys, sizeof(char *) * capacity);
-                    values = realloc(values, sizeof(ASTNode *) * capacity);
+                    ARRAY_GROW(keys, count, capacity, char *, abort());
+                    ARRAY_GROW(values, count, capacity, ASTNode *, abort());
                 }
                 
                 // キー（文字列または識別子）
@@ -1860,8 +1841,7 @@ static ASTNode *primary(Parser *parser) {
         if (!check(parser, TOKEN_RPAREN)) {
             do {
                 if (count >= capacity) {
-                    capacity *= 2;
-                    args = realloc(args, sizeof(ASTNode *) * capacity);
+                    ARRAY_GROW(args, count, capacity, ASTNode *, abort());
                 }
                 args[count++] = expression(parser);
             } while (match(parser, TOKEN_COMMA));

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -397,11 +397,23 @@ bool plugin_load(PluginManager *mgr, const char *path, HajimuPluginInfo **info_o
     }
     
     // プラグインを登録
-    LoadedPlugin *p = &mgr->plugins[mgr->count++];
+    LoadedPlugin *p = &mgr->plugins[mgr->count];
     p->path = strdup(path);
+    if (p->path == NULL) {
+        fprintf(stderr, "エラー: メモリを確保できません: %s\n", path);
+        platform_dlclose(handle);
+        return false;
+    }
     p->name = strdup(info->name);
+    if (p->name == NULL) {
+        fprintf(stderr, "エラー: メモリを確保できません: %s\n", info->name);
+        free(p->path);
+        platform_dlclose(handle);
+        return false;
+    }
     p->handle = handle;
     p->info = info;
+    mgr->count++;
     
     if (info_out) *info_out = info;
     

--- a/src/value.c
+++ b/src/value.c
@@ -3,6 +3,7 @@
  */
 
 #include "value.h"
+#include "array_grow.h"
 #include "environment.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -113,6 +114,9 @@ Value value_class(const char *name, struct ASTNode *definition, Value *parent) {
     v.is_const = true;
     v.ref_count = 1;
     v.class_value.name = strdup(name);
+    if (v.class_value.name == NULL) {
+        return value_null();
+    }
     v.class_value.definition = definition;
     v.class_value.parent = parent;
     return v;
@@ -178,9 +182,13 @@ void instance_set_field(Value *instance, const char *name, Value value) {
         instance->instance.field_capacity = new_cap;
     }
     
-    int idx = instance->instance.field_count++;
+    int idx = instance->instance.field_count;
     instance->instance.field_names[idx] = strdup(name);
+    if (instance->instance.field_names[idx] == NULL) {
+        return;
+    }
     instance->instance.fields[idx] = value_copy(value);
+    instance->instance.field_count++;
 }
 
 Value *instance_get_field(Value *instance, const char *name) {
@@ -237,6 +245,15 @@ Value value_copy(Value v) {
             copy.dict.values = malloc(sizeof(Value) * v.dict.capacity);
             for (int i = 0; i < v.dict.length; i++) {
                 copy.dict.keys[i] = strdup(v.dict.keys[i]);
+                if (copy.dict.keys[i] == NULL) {
+                    for (int j = 0; j < i; j++) {
+                        free(copy.dict.keys[j]);
+                        value_free(&copy.dict.values[j]);
+                    }
+                    free(copy.dict.keys);
+                    free(copy.dict.values);
+                    return value_null();
+                }
                 copy.dict.values[i] = value_copy(v.dict.values[i]);
             }
             copy.ref_count = 1;
@@ -253,6 +270,9 @@ Value value_copy(Value v) {
         case VALUE_CLASS:
             // クラス名と親クラスをディープコピー
             copy.class_value.name = strdup(v.class_value.name);
+            if (copy.class_value.name == NULL) {
+                return value_null();
+            }
             if (v.class_value.parent != NULL) {
                 copy.class_value.parent = malloc(sizeof(Value));
                 *copy.class_value.parent = value_copy(*v.class_value.parent);
@@ -266,6 +286,15 @@ Value value_copy(Value v) {
             copy.instance.fields = malloc(sizeof(Value) * v.instance.field_capacity);
             for (int i = 0; i < v.instance.field_count; i++) {
                 copy.instance.field_names[i] = strdup(v.instance.field_names[i]);
+                if (copy.instance.field_names[i] == NULL) {
+                    for (int j = 0; j < i; j++) {
+                        free(copy.instance.field_names[j]);
+                        value_free(&copy.instance.fields[j]);
+                    }
+                    free(copy.instance.field_names);
+                    free(copy.instance.fields);
+                    return value_null();
+                }
                 copy.instance.fields[i] = value_copy(v.instance.fields[i]);
             }
             if (v.instance.class_ref != NULL) {
@@ -431,10 +460,12 @@ void array_push(Value *array, Value element) {
     
     // 容量が足りなければ拡張
     if (array->array.length >= array->array.capacity) {
-        array->array.capacity *= 2;
-        array->array.elements = realloc(
-            array->array.elements, 
-            sizeof(Value) * array->array.capacity
+        ARRAY_GROW(
+            array->array.elements,
+            array->array.length,
+            array->array.capacity,
+            Value,
+            abort()
         );
     }
     
@@ -512,13 +543,15 @@ bool dict_set(Value *dict, const char *key, Value value) {
     
     // 容量が足りなければ拡張
     if (dict->dict.length >= dict->dict.capacity) {
-        dict->dict.capacity *= 2;
-        dict->dict.keys = realloc(dict->dict.keys, sizeof(char *) * dict->dict.capacity);
-        dict->dict.values = realloc(dict->dict.values, sizeof(Value) * dict->dict.capacity);
+        ARRAY_GROW(dict->dict.keys, dict->dict.length, dict->dict.capacity, char *, abort());
+        ARRAY_GROW(dict->dict.values, dict->dict.length, dict->dict.capacity, Value, abort());
     }
     
     // 新しいキーを追加
     dict->dict.keys[dict->dict.length] = strdup(key);
+    if (dict->dict.keys[dict->dict.length] == NULL) {
+        return false;
+    }
     dict->dict.values[dict->dict.length] = value_copy(value);
     dict->dict.length++;
     
@@ -736,6 +769,9 @@ char *value_to_string(Value v) {
     switch (v.type) {
         case VALUE_NULL:
             buffer = strdup("null");
+            if (buffer == NULL) {
+                return NULL;
+            }
             break;
             
         case VALUE_NUMBER: {
@@ -752,6 +788,9 @@ char *value_to_string(Value v) {
         
         case VALUE_BOOL:
             buffer = strdup(v.boolean ? "真" : "偽");
+            if (buffer == NULL) {
+                return NULL;
+            }
             break;
             
         case VALUE_STRING:
@@ -770,8 +809,7 @@ char *value_to_string(Value v) {
             for (int i = 0; i < v.array.length; i++) {
                 if (i > 0) {
                     if (length + 2 >= capacity) {
-                        capacity *= 2;
-                        buffer = realloc(buffer, capacity);
+                        ARRAY_GROW(buffer, length + 2, capacity, char, abort());
                     }
                     buffer[length++] = ',';
                     buffer[length++] = ' ';
@@ -781,8 +819,7 @@ char *value_to_string(Value v) {
                 size_t elem_len = strlen(elem_str);
                 
                 while (length + elem_len + 2 >= capacity) {
-                    capacity *= 2;
-                    buffer = realloc(buffer, capacity);
+                    ARRAY_GROW(buffer, length + elem_len + 2, capacity, char, abort());
                 }
                 
                 memcpy(buffer + length, elem_str, elem_len);
@@ -805,8 +842,7 @@ char *value_to_string(Value v) {
             for (int i = 0; i < v.dict.length; i++) {
                 if (i > 0) {
                     if (length + 2 >= capacity) {
-                        capacity *= 2;
-                        buffer = realloc(buffer, capacity);
+                        ARRAY_GROW(buffer, length + 2, capacity, char, abort());
                     }
                     buffer[length++] = ',';
                     buffer[length++] = ' ';
@@ -815,8 +851,7 @@ char *value_to_string(Value v) {
                 // キー
                 size_t key_len = strlen(v.dict.keys[i]);
                 while (length + key_len + 5 >= capacity) {
-                    capacity *= 2;
-                    buffer = realloc(buffer, capacity);
+                    ARRAY_GROW(buffer, length + key_len + 5, capacity, char, abort());
                 }
                 buffer[length++] = '"';
                 memcpy(buffer + length, v.dict.keys[i], key_len);
@@ -830,8 +865,7 @@ char *value_to_string(Value v) {
                 size_t val_len = strlen(val_str);
                 
                 while (length + val_len + 2 >= capacity) {
-                    capacity *= 2;
-                    buffer = realloc(buffer, capacity);
+                    ARRAY_GROW(buffer, length + val_len + 2, capacity, char, abort());
                 }
                 
                 memcpy(buffer + length, val_str, val_len);


### PR DESCRIPTION
## Summary

- **fix: strdup の戻り値に NULL チェックを追加 (#16)**
  - `src/main.c`, `src/value.c`, `src/plugin.c` の全 strdup 呼び出しにNULLハンドリング追加
  - メモリ不足時のクラッシュを防止

- **refactor: 動的配列拡張パターンを ARRAY_GROW マクロに集約 (#8)**
  - `src/array_grow.h` 新規作成（`do {...} while(0)` ラッパー、realloc NULLチェック内蔵）
  - 5ファイル36箇所の重複パターンをマクロに置換
  - parser(10), evaluator(9), value(8), http(5), lexer(4)

## Test plan

- [x] `make` クリーンコンパイル（-Wall -Wextra 警告ゼロ）
- [x] `make test` 全テストパス
- [ ] Cコード変更のためメモリリーク確認（valgrind/ASan）

Closes #16, Closes #8

> 🤖 Claude による返信